### PR TITLE
Prevent curl output being sent to browser

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -162,6 +162,7 @@ class assign_submission_estream extends assign_submission_plugin
             }
             curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 60);
             curl_setopt($curl, CURLOPT_TIMEOUT, 60);
+            curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
             $content = curl_exec($curl);
         } catch (Exception $e) {
             // Non-fatal exception!


### PR DESCRIPTION
On resetting a course in Moodle with "delete all submissions" switched on, we're seeing our browser redirected to "/course/UploadSubmissionVLE.aspx?mad=1&checksum=3aeeaa01adc76b95af2cf58d37525267", resulting in a 404 error.

This is because the delete_instance() method on your plugin is making curl requests and letting the response HTML be passed to the browser, resulting in unpredictable behaviour. This patch prevents this from happening, and makes the course reset behave as expected.

Hope it's useful!

Cheers, Michael
