### PR TITLE
fix bug with php 8.0 itemtitle is empty which leads to upload failed …

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -376,8 +376,8 @@ public function remove(stdClass $submission) {
         $embedcode = "";
         $url = $CFG->httpswwwroot . '/mod/assign/submission/estream/upload.php';
         $itemtitle = "Submission by " . fullname($USER);
-        if (strlen($itemtitle > 120)) {
-            $itemtitle = substr($itemtitle, 120);
+        if (strlen($itemtitle) > 120) {
+            $itemtitle = substr($itemtitle, 0, 120);
         }
         $itemdesc = "Assignment : " . $this->assignment->get_instance()->name . "\r\n";
         $itemdesc .= "Course : " . $COURSE->fullname . "\r\n";


### PR DESCRIPTION
php 8.0 changes the behavior of the following code:

if (strlen($itemtitle > 120)) {
            $itemtitle = substr($itemtitle, 120);
}

so that $itemtitle is empty and the submission upload shows an error message "upload failed".

The problems are:

- greater comparision as parameter of the strlen function
- substr has offset as second parameter and length as third parameter

The following Testscript shows the difference on php 7.4 and php 8.0 

```
<?php
$itemtitle = "Submission by Full Username";
var_dump($itemtitle);
var_dump(($itemtitle > 120));
var_dump(strlen($itemtitle > 120));
if (strlen($itemtitle > 120)) {
  var_dump($itemtitle);
  $itemtitle = substr($itemtitle, 120);
}
var_dump($itemtitle);
```

php7.4 test.php
``` 
string(27) "Submission by Full Username"
bool(false)
int(0)
string(27) "Submission by Full Username"

```
php8.0 test.php
```
string(27) "Submission by Full Username"
bool(true)
int(1)
string(27) "Submission by Full Username"
string(0) ""

```
Cheers,
Harald
