### PR TITLE
Refactor estream submission plugin and bump version

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,5 +1,5 @@
 <?php
-// …
+// ï¿½
 
 namespace assignsubmission_estream\privacy;
 
@@ -15,40 +15,42 @@ use \core_privacy\local\request\contextlist;
 use \mod_assign\privacy\assign_plugin_request_data;
 use \mod_assign\privacy\useridlist;
 
-class provider implements metadataprovider, \mod_assign\privacy\assignsubmission_provider {
+class provider implements metadataprovider, \mod_assign\privacy\assignsubmission_provider
+{
 
-public static function get_metadata(collection $collection): collection {
+    public static function get_metadata(collection $collection): collection
+    {
 
-	$collection->add_external_location_link('assignsubmission_estream', [
+        $collection->add_external_location_link('assignsubmission_estream', [
             'userid' => 'privacy:metadata:assignsubmission_estream:userid',
             'fullname' => 'privacy:metadata:assignsubmission_estream:fullname',
-		    'email' => 'privacy:metadata:assignsubmission_estream:email',
+            'email' => 'privacy:metadata:assignsubmission_estream:email',
             'userip' => 'privacy:metadata:assignsubmission_estream:userip',
         ], 'privacy:metadata:assignsubmission_estream');
 
-    $collection->add_database_table(
-        'assignsubmission_estream',
-         [
-            'assignment' => 'privacy:metadata:assignsubmission_estream:assignment',
-            'submission' => 'privacy:metadata:assignsubmission_estream:submission',
-            'cdid' => 'privacy:metadata:assignsubmission_estream:cdid',
-			'embedcode' => 'privacy:metadata:assignsubmission_estream:embedcode',
+        $collection->add_database_table(
+            'assignsubmission_estream',
+            [
+                'assignment' => 'privacy:metadata:assignsubmission_estream:assignment',
+                'submission' => 'privacy:metadata:assignsubmission_estream:submission',
+                'cdid' => 'privacy:metadata:assignsubmission_estream:cdid',
+                'embedcode' => 'privacy:metadata:assignsubmission_estream:embedcode',
 
-         ],
-        'privacy:metadata:assignsubmission_estream'
-    );
-	
-    return $collection;
-	
-}
+            ],
+            'privacy:metadata:assignsubmission_estream'
+        );
 
- /**
+        return $collection;
+    }
+
+    /**
      * This is covered by mod_assign provider and the query on assign_submissions.
      *
      * @param  int $userid The user ID that we are finding contexts for.
      * @param  contextlist $contextlist A context list to add sql and params to for contexts.
      */
-    public static function get_context_for_userid_within_submission(int $userid, contextlist $contextlist) {
+    public static function get_context_for_userid_within_submission(int $userid, contextlist $contextlist)
+    {
         // This is already fetched from mod_assign.
     }
 
@@ -57,7 +59,8 @@ public static function get_metadata(collection $collection): collection {
      *
      * @param  \mod_assign\privacy\useridlist $useridlist An object for obtaining user IDs of students.
      */
-    public static function get_student_user_ids(\mod_assign\privacy\useridlist $useridlist) {
+    public static function get_student_user_ids(\mod_assign\privacy\useridlist $useridlist)
+    {
         // No need.
     }
 
@@ -67,8 +70,9 @@ public static function get_metadata(collection $collection): collection {
      * @param  assign_plugin_request_data $exportdata Data used to determine which context and user to export and other useful
      * information to help with exporting.
      */
-    public static function export_submission_user_data(assign_plugin_request_data $exportdata) {
-        global $DB;       
+    public static function export_submission_user_data(assign_plugin_request_data $exportdata)
+    {
+        global $DB;
         if ($exportdata->get_user() != null) {
             return null;
         }
@@ -89,7 +93,8 @@ public static function get_metadata(collection $collection): collection {
      *
      * @param  assign_plugin_request_data $requestdata Data to fulfill the deletion request.
      */
-    public static function delete_submission_for_context(assign_plugin_request_data $requestdata) {
+    public static function delete_submission_for_context(assign_plugin_request_data $requestdata)
+    {
         global $DB;
         $DB->delete_records('assignsubmission_estream', ['assignment' => $requestdata->get_assign()->get_instance()->id]);
     }
@@ -99,15 +104,16 @@ public static function get_metadata(collection $collection): collection {
      *
      * @param  assign_plugin_request_data $deletedata Details about the user and context to focus the deletion.
      */
-    public static function delete_submission_for_userid(assign_plugin_request_data $deletedata) {
+    public static function delete_submission_for_userid(assign_plugin_request_data $deletedata)
+    {
         global $DB;
 
         $submissionid = $deletedata->get_pluginobject()->id;
 
         // Delete the records in the table.
-        $DB->delete_records('assignsubmission_estream', ['assignment' => $deletedata->get_assign()->get_instance()->id,
-            'submission' => $submissionid]);
-
+        $DB->delete_records('assignsubmission_estream', [
+            'assignment' => $deletedata->get_assign()->get_instance()->id,
+            'submission' => $submissionid
+        ]);
     }
-
 }

--- a/db/access.php
+++ b/db/access.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * db/capabilities stub for the Planet eStream Assignment Submission Plugin
  *

--- a/db/install.php
+++ b/db/install.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * Post-install code for the Planet eStream Assignment Submission Plugin
  *
@@ -22,7 +23,8 @@
  *
  */
 defined('MOODLE_INTERNAL') || die();
-function xmldb_assignsubmission_estream_install() {
+function xmldb_assignsubmission_estream_install()
+{
         global $CFG;
         require_once($CFG->dirroot . '/mod/assign/adminlib.php');
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * DB/upgrade stub for the Planet eStream Assignment Submission Plugin
  *
@@ -21,11 +22,12 @@
  * @license        http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  */
-function xmldb_assignsubmission_estream_upgrade($oldversion) {
+function xmldb_assignsubmission_estream_upgrade($oldversion)
+{
     global $CFG, $DB;
     $dbman = $DB->get_manager();
-	
-	 if ($oldversion < 2021061406) {
+
+    if ($oldversion < 2021061406) {
 
         // Changing type of field cdid on table assignsubmission_estream to char.
         $table = new xmldb_table('assignsubmission_estream');
@@ -33,8 +35,8 @@ function xmldb_assignsubmission_estream_upgrade($oldversion) {
 
         // Launch change of type for field cdid.
         $dbman->change_field_type($table, $field);
-		
-		 // Changing precision of field embedcode on table assignsubmission_estream to (200).
+
+        // Changing precision of field embedcode on table assignsubmission_estream to (200).
         $table = new xmldb_table('assignsubmission_estream');
         $field = new xmldb_field('embedcode', XMLDB_TYPE_CHAR, '1333', null, XMLDB_NOTNULL, null, '0', 'cdid');
 

--- a/lang/en/assignsubmission_estream.php
+++ b/lang/en/assignsubmission_estream.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * Strings for the Planet eStream Assignment Submission Plugin, language 'en'
  *

--- a/lib.php
+++ b/lib.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * library class for the Planet eStream Assignment Submission Plugin
  *

--- a/locallib.php
+++ b/locallib.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * local library class for the Planet eStream Assignment Submission Plugin
  * extends submission plugin base class
@@ -29,8 +30,9 @@ class assign_submission_estream extends assign_submission_plugin
      * Get the name of the online text submission plugin
      * @return string
      */
-    public function get_name() {
-            return get_string('shortname', 'assignsubmission_estream');
+    public function get_name()
+    {
+        return get_string('shortname', 'assignsubmission_estream');
     }
     /**
      * Save the submission plugin settings
@@ -38,8 +40,9 @@ class assign_submission_estream extends assign_submission_plugin
      * @param stdClass $data
      * @return bool
      */
-    public function save_settings(stdClass $data) {
-            return true;
+    public function save_settings(stdClass $data)
+    {
+        return true;
     }
     /**
      * Read the submission information from the database
@@ -47,47 +50,56 @@ class assign_submission_estream extends assign_submission_plugin
      * @param  int $submissionid
      * @return mixed
      */
-    private function funcgetsubmission($submissionid) {
-            global $DB;
-            return $DB->get_record('assignsubmission_estream', array(
-                    'submission' => $submissionid
-            ));
+    private function funcgetsubmission($submissionid)
+    {
+        global $DB;
+        return $DB->get_record('assignsubmission_estream', array(
+            'submission' => $submissionid
+        ));
+    }
+
+    /**
+     * Determine whether a cdid value is empty.
+     *
+     * @param mixed $cdid
+     * @return bool
+     */
+    private function is_empty_cdid($cdid)
+    {
+        return trim((string)$cdid) === '';
     }
     /**
      * Embed the player
      *
      * @return string
      */
-    public function funcembedplayer($cdid, $embedcode) {
-        $url = rtrim(get_config('assignsubmission_estream', 'url') , '/');
+    public function funcembedplayer($cdid, $embedcode)
+    {
+        $url = rtrim(get_config('assignsubmission_estream', 'url'), '/');
         if ($cdid == "") {
             return "<p>" . get_config('assignsubmission_estream', 'emptyoverride') . "</p>";
         } else {
-			
-			   if(strpos($cdid, '¬') !== false){ // Multiple uploads
-			   
-	$CDIDs = explode("¬", $cdid);
-				 $Codes = explode("¬", $embedcode);	
-				 $strReturn = '';
 
-				  for($i = 0;$i<count($CDIDs);$i++){
+            if (strpos($cdid, '¬') !== false) { // Multiple uploads
 
-			 $strReturn .="<iframe allowfullscreen height=\"198\" width=\"352\" src=\"".$url."/Embed.aspx?id=".$CDIDs[$i]
-            ."&amp;code=".$Codes[$i]."&amp;wmode=opaque&amp;viewonestream=0\" frameborder=\"0\"></iframe>&nbsp;";
-					 
-				}
-				
-				return $strReturn;
-				
-				      return "<iframe allowfullscreen height=\"198\" width=\"352\" src=\"".$url."/Embed.aspx?id=123&amp;code=123&amp;wmode=opaque&amp;viewonestream=0\" frameborder=\"0\"></iframe>";
- 
-			   } else {
-				   
-				        return "<iframe allowfullscreen height=\"198\" width=\"352\" src=\"".$url."/Embed.aspx?id=".$cdid
-            ."&amp;code=".$embedcode."&amp;wmode=opaque&amp;viewonestream=0\" frameborder=\"0\"></iframe>";
-				   
-			   }
-			       
+                $CDIDs = explode("¬", $cdid);
+                $Codes = explode("¬", $embedcode);
+                $strReturn = '';
+
+                for ($i = 0; $i < count($CDIDs); $i++) {
+
+                    $strReturn .= "<iframe allowfullscreen height=\"198\" width=\"352\" src=\"" . $url . "/Embed.aspx?id=" . $CDIDs[$i]
+                        . "&amp;code=" . $Codes[$i] . "&amp;wmode=opaque&amp;viewonestream=0\" frameborder=\"0\"></iframe>&nbsp;";
+                }
+
+                return $strReturn;
+
+                return "<iframe allowfullscreen height=\"198\" width=\"352\" src=\"" . $url . "/Embed.aspx?id=123&amp;code=123&amp;wmode=opaque&amp;viewonestream=0\" frameborder=\"0\"></iframe>";
+            } else {
+
+                return "<iframe allowfullscreen height=\"198\" width=\"352\" src=\"" . $url . "/Embed.aspx?id=" . $cdid
+                    . "&amp;code=" . $embedcode . "&amp;wmode=opaque&amp;viewonestream=0\" frameborder=\"0\"></iframe>";
+            }
         }
     }
     /**
@@ -97,107 +109,66 @@ class assign_submission_estream extends assign_submission_plugin
      * @param stdClass $data
      * @return bool
      */
-    public function save(stdClass $submission, stdClass $data) {
-		
-		
-		
-	    try {			
-		
-			 global $DB;
-			 $thissubmission = $this->funcgetsubmission($submission->id);
-			 			 			 
-			  if(empty($thissubmission->id)) { // New submission
-				  
-				 if (empty($data->cdid)) { // Not adding vid
-			
-					if (get_config('assignsubmission_estream', 'forcesubmit') == true) {
-				
-					// Do nothing, user is forced to submit something
-					echo 'new, nothing, force';
-					
-						$this->set_error(get_string('error_force', 'assignsubmission_estream', $this->get_error()));
-					return false;
-				
-					} else {
-						
-						echo 'new, nothing, no force';
-				
-						    $thissubmission = new stdClass();
-							$thissubmission->submission = $submission->id;
-							$thissubmission->assignment = $this->assignment->get_instance()->id;
-							$thissubmission->embedcode = "";
-							$thissubmission->cdid = "";
-							return $DB->insert_record('assignsubmission_estream', $thissubmission) > 0;
-				
-					}
-			
-				} else { // New sub, add video(s)
-							 
-				  echo 'new, video';
-							 
-					 $thissubmission = new stdClass();
-                    $thissubmission->submission = $submission->id;
-                    $thissubmission->assignment = $this->assignment->get_instance()->id;
-                    $thissubmission->embedcode = $data->embedcode;
-                    $thissubmission->cdid = $data->cdid;
-                    return $DB->insert_record('assignsubmission_estream', $thissubmission) > 0;		 
-					
-				}
-				  
-			} else { // Existing submission
-				  
-				if($data->cdid == $thissubmission->cdid) { // Overwriting with nothing
-			        
-					if (get_config('assignsubmission_estream', 'forcesubmit') == true) {
-				
-					// Do nothing, user is forced to submit something
-					
-					echo 'exist, nothing, force';
-					
-					$this->set_error(get_string('error_force', 'assignsubmission_estream', $this->get_error()));
-					return false;
-				
-					} else {
-						
-						echo 'exist, nothing, no force';
-						
-						if (get_config('assignsubmission_estream', 'overwriteblank') == true) {
-														
-						$thissubmission->submission = $submission->id;
-						$thissubmission->assignment = $this->assignment->get_instance()->id;
-						$thissubmission->embedcode = "";
-						$thissubmission->cdid = "";
-						return $DB->update_record('assignsubmission_estream', $thissubmission);
-							
-						} else {
-							
-							
-					
-						return true;						
-						
-						} 
-																	
-					}
-											
-				} else { 
-				
-				echo 'exist, video';
-				
-                     $thissubmission->submission = $submission->id;
-                    $thissubmission->assignment = $this->assignment->get_instance()->id;
-                    $thissubmission->embedcode = $data->embedcode;
-                    $thissubmission->cdid = $data->cdid;
-                    return $DB->update_record('assignsubmission_estream', $thissubmission);		
-					
-				}
-				  
-		 }
-		
+    public function save(stdClass $submission, stdClass $data)
+    {
+        try {
+            global $DB;
+            $thissubmission = $this->funcgetsubmission($submission->id);
+
+            $incomingcdid = isset($data->cdid) ? trim((string)$data->cdid) : '';
+            $incomingembedcode = isset($data->embedcode) ? trim((string)$data->embedcode) : '';
+            $hasincomingitem = !$this->is_empty_cdid($incomingcdid);
+
+            if (!$thissubmission) {
+                if (!$hasincomingitem && get_config('assignsubmission_estream', 'forcesubmit')) {
+                    $this->set_error(get_string('error_force', 'assignsubmission_estream'));
+                    return false;
+                }
+
+                $thissubmission = new stdClass();
+                $thissubmission->submission = $submission->id;
+                $thissubmission->assignment = $this->assignment->get_instance()->id;
+                $thissubmission->embedcode = $hasincomingitem ? $incomingembedcode : '';
+                $thissubmission->cdid = $hasincomingitem ? $incomingcdid : '';
+
+                return $DB->insert_record('assignsubmission_estream', $thissubmission) > 0;
+            }
+
+            $storedcdid = trim((string)$thissubmission->cdid);
+            $storedembedcode = trim((string)$thissubmission->embedcode);
+            $hasstoreditem = !$this->is_empty_cdid($storedcdid);
+
+            if (!$hasincomingitem) {
+                if (get_config('assignsubmission_estream', 'forcesubmit')) {
+                    $this->set_error(get_string('error_force', 'assignsubmission_estream'));
+                    return false;
+                }
+
+                if (!$hasstoreditem) {
+                    return true;
+                }
+
+                if (!get_config('assignsubmission_estream', 'overwriteblank')) {
+                    return true;
+                }
+
+                $thissubmission->assignment = $this->assignment->get_instance()->id;
+                $thissubmission->embedcode = '';
+                $thissubmission->cdid = '';
+                return $DB->update_record('assignsubmission_estream', $thissubmission);
+            }
+
+            if ($incomingcdid === $storedcdid && $incomingembedcode === $storedembedcode) {
+                return true;
+            }
+
+            $thissubmission->assignment = $this->assignment->get_instance()->id;
+            $thissubmission->embedcode = $incomingembedcode;
+            $thissubmission->cdid = $incomingcdid;
+            return $DB->update_record('assignsubmission_estream', $thissubmission);
         } catch (Exception $e) {
-			
-           echo 'Error: ' . $e;
-		   
-            // Non-fatal exception!
+            debugging('assignsubmission_estream save failed: ' . $e->getMessage(), DEBUG_DEVELOPER);
+            return false;
         }
     }
     /**
@@ -206,7 +177,8 @@ class assign_submission_estream extends assign_submission_plugin
      * @param stdClass $submission
      * @return string
      */
-    public function view(stdClass $submission) {
+    public function view(stdClass $submission)
+    {
         $thissubmission = $this->funcgetsubmission($submission->id);
         if ($thissubmission) {
             return $this->funcembedplayer($thissubmission->cdid, $thissubmission->embedcode);
@@ -221,7 +193,8 @@ class assign_submission_estream extends assign_submission_plugin
      * @param bool $showviewlink Set this to true if the list of files is long
      * @return string
      */
-    public function view_summary(stdClass $submission, &$showviewlink) {
+    public function view_summary(stdClass $submission, &$showviewlink)
+    {
         return $this->view($submission);
     }
     /**
@@ -231,100 +204,98 @@ class assign_submission_estream extends assign_submission_plugin
      * @param int $version old assignment version
      * @return bool True if upgrade is possible
      */
-    public function can_upgrade($type, $version) {
+    public function can_upgrade($type, $version)
+    {
         return false;
     }
-  
-	 
-	public function atto_planetestream_obfuscate($strx) {
-    $strbase64chars = '0123456789aAbBcCDdEeFfgGHhiIJjKklLmMNnoOpPQqRrsSTtuUvVwWXxyYZz/+=';
-    $strbase64string = base64_encode($strx);
-    if ($strbase64string == '') {
-        return '';
-    }
-    $strobfuscated = '';
-    for ($i = 0; $i < strlen ($strbase64string); $i ++) {
-        $intpos = strpos($strbase64chars, substr($strbase64string, $i, 1));
-        if ($intpos == - 1) {
+
+
+    public function atto_planetestream_obfuscate($strx)
+    {
+        $strbase64chars = '0123456789aAbBcCDdEeFfgGHhiIJjKklLmMNnoOpPQqRrsSTtuUvVwWXxyYZz/+=';
+        $strbase64string = base64_encode($strx);
+        if ($strbase64string == '') {
             return '';
         }
-        $intpos += strlen($strbase64string ) + $i;
-        $intpos = $intpos % strlen($strbase64chars);
-        $strobfuscated .= substr($strbase64chars, $intpos, 1);
-    }
-    return urlencode($strobfuscated);
-}
-	 
-	 
-	 function atto_planetestream_getchecksum() {
-    $decchecksum = (float)(date('d') + date('m')) + (date('m') * date('d')) + (date('Y') * date('d'));
-    $decchecksum += $decchecksum * (date('d') * 2.27409) * .689274;
-    return md5(floor($decchecksum));
-}
-
-
-function atto_planetestream_getauthticket($url, $checksum, $delta, $userip, &$params) {
-    $return = '';
-	
-	//$return = $url . "~~~" . $checksum . "~~~~" . $delta . "~~~~" . $userip;
-    try {
-        $url .= '/VLE/Moodle/Auth/?source=1&assign=1&checksum=' . $checksum . '&delta=' . $delta . '&u=' . $userip;
-        if (!$curl = curl_init($url)) {
-           return '';
-		   //return $return;
+        $strobfuscated = '';
+        for ($i = 0; $i < strlen($strbase64string); $i++) {
+            $intpos = strpos($strbase64chars, substr($strbase64string, $i, 1));
+            if ($intpos == -1) {
+                return '';
+            }
+            $intpos += strlen($strbase64string) + $i;
+            $intpos = $intpos % strlen($strbase64chars);
+            $strobfuscated .= substr($strbase64chars, $intpos, 1);
         }
-        curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 15);
-        curl_setopt($curl, CURLOPT_TIMEOUT, 15);
-        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
-        curl_setopt($curl, CURLOPT_MAXREDIRS, 4);
-        curl_setopt($curl, CURLOPT_FORBID_REUSE, true);
-        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
-        $response = curl_exec($curl);
-        if (strpos($response, '{"ticket":') === 0) {
-            $jobj = json_decode($response);
-            $return = $jobj->ticket;
-            $params['estream_height'] = $jobj->height;
-            $params['estream_width'] = $jobj->width;
+        return urlencode($strobfuscated);
+    }
+
+
+    function atto_planetestream_getchecksum()
+    {
+        $decchecksum = (float)(date('d') + date('m')) + (date('m') * date('d')) + (date('Y') * date('d'));
+        $decchecksum += $decchecksum * (date('d') * 2.27409) * .689274;
+        return md5(floor($decchecksum));
+    }
+
+
+    function atto_planetestream_getauthticket($url, $checksum, $delta, $userip, &$params)
+    {
+        $return = '';
+
+        //$return = $url . "~~~" . $checksum . "~~~~" . $delta . "~~~~" . $userip;
+        try {
+            $url .= '/VLE/Moodle/Auth/?source=1&assign=1&checksum=' . $checksum . '&delta=' . $delta . '&u=' . $userip;
+            if (!$curl = curl_init($url)) {
+                return '';
+                //return $return;
+            }
+            curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 15);
+            curl_setopt($curl, CURLOPT_TIMEOUT, 15);
+            curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+            curl_setopt($curl, CURLOPT_MAXREDIRS, 4);
+            curl_setopt($curl, CURLOPT_FORBID_REUSE, true);
+            curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
+            $response = curl_exec($curl);
+            if (strpos($response, '{"ticket":') === 0) {
+                $jobj = json_decode($response);
+                $return = $jobj->ticket;
+                $params['estream_height'] = $jobj->height;
+                $params['estream_width'] = $jobj->width;
+            }
+        } catch (Exception $e) {
+            // ... non-fatal ...
         }
-    } catch (Exception $e) {
-        // ... non-fatal ...
-    }
-    return $return;
-}
-
-public function remove(stdClass $submission) {
-      //  global $DB;
-        //delete database record
-     //   $submissionid = $submission ? $submission->id : 0;
-      //  if ($submissionid) {
-         //   $DB->delete_records('assignsubmission_estream', array(
-               // 'assignment' => $this->assignment->get_instance()->id
-    //    ));
-
-            //delete recorded files
-           // $fs = get_file_storage();
-           // $fs->delete_area_files($this->assignment->get_context()->id,
-                  //  'assignsubmission_planetestream',
-                  //  constants::'onlinepoodll_backimage',
-                  //  $submission->id);
-      //  }
-
-
-
-      //  return true;
+        return $return;
     }
 
-	 
-   public function delete_instance() {
+    public function remove(stdClass $submission)
+    {
+        global $DB;
+
+        if (empty($submission->id)) {
+            return true;
+        }
+
+        $DB->delete_records('assignsubmission_estream', array(
+            'submission' => $submission->id
+        ));
+
+        return true;
+    }
+
+
+    public function delete_instance()
+    {
         global $DB;
         $DB->delete_records('assignsubmission_estream', array(
-                'assignment' => $this->assignment->get_instance()->id
+            'assignment' => $this->assignment->get_instance()->id
         ));
         try {
-            $cs = ( float )(date('d') + date('m')) + (date('m') * date('d')) + (date('Y') * date('d'));
+            $cs = (float)(date('d') + date('m')) + (date('m') * date('d')) + (date('Y') * date('d'));
             $cs += $cs * (date('d') * 2.27409) * .689274;
-            $url = rtrim(get_config('assignsubmission_estream', 'url') , '/');       
+            $url = rtrim(get_config('assignsubmission_estream', 'url'), '/');
             $url = $url . "/UploadSubmissionVLE.aspx?mad=" . $this->assignment->get_instance()->id . "&checksum=" . md5(floor($cs));
             if (!$curl = curl_init($url)) {
                 $this->log('curl init failed [187].');
@@ -346,9 +317,26 @@ public function remove(stdClass $submission) {
      * @param stdClass $submission
      * @return bool
      */
-    public function is_empty(stdClass $submission) {
-       return $this->view($submission) == ''; 	
-	 /* Return false does not work. Return true 'works' in the sense that it doesn't regardless of file  */
+    public function is_empty(stdClass $submission)
+    {
+        $thissubmission = $this->funcgetsubmission($submission->id);
+        if (!$thissubmission) {
+            return true;
+        }
+
+        return $this->is_empty_cdid($thissubmission->cdid);
+    }
+
+    /**
+     * Determine if a new submission is empty before save.
+     *
+     * @param stdClass $data
+     * @return bool
+     */
+    public function submission_is_empty(stdClass $data)
+    {
+        $cdid = isset($data->cdid) ? $data->cdid : '';
+        return $this->is_empty_cdid($cdid);
     }
     /**
      * Add form elements
@@ -358,42 +346,50 @@ public function remove(stdClass $submission) {
      * @param stdClass $data
      * @return true if elements were added to the form
      */
-    public function get_form_elements($submission, MoodleQuickForm $mform, stdClass $data) {
+    public function get_form_elements($submission, MoodleQuickForm $mform, stdClass $data)
+    {
         global $CFG, $USER, $PAGE, $COURSE;
         $cdid = "";
         $embedcode = "";
-        $url = $CFG->httpswwwroot . '/mod/assign/submission/estream/upload.php';
+        $url = new moodle_url('/mod/assign/submission/estream/upload.php', array(
+            'id' => $this->assignment->get_course_module()->id,
+            'sesskey' => sesskey()
+        ));
         $itemtitle = "Submission by " . fullname($USER);
-       if (strlen($itemtitle) > 120) {
+        if (strlen($itemtitle) > 120) {
             $itemtitle = substr($itemtitle, 0, 120);
         }
         $itemdesc = "Assignment : " . $this->assignment->get_instance()->name . "\r\n";
         $itemdesc .= "Course : " . $COURSE->fullname . "\r\n";
-        $url .= '?itemtitle=' . urlencode($itemtitle);
-        $url .= '&itemdesc=' . urlencode($itemdesc);
-        $url .= '&itemaid=' . urlencode($this->assignment->get_instance()->id);
-        $url .= '&itemuid=' . urlencode($USER->id);
-        $url .= '&itemcid=' . urlencode($COURSE->id);
+        $url->param('itemtitle', $itemtitle);
+        $url->param('itemdesc', $itemdesc);
+        $url->param('itemaid', $this->assignment->get_instance()->id);
+        $url->param('itemuid', $USER->id);
+        $url->param('itemcid', $COURSE->id);
         if ($submission) {
             $thissubmission = $this->funcgetsubmission($submission->id);
             if ($thissubmission) {
                 $cdid = $thissubmission->cdid;
                 $embedcode = $thissubmission->embedcode;
                 $iframehtml = $this->funcembedplayer($cdid, $embedcode);
-                $mform->addElement('static', 'currentsubmission',
-                get_string('currentsubmission', 'assignsubmission_estream') , $iframehtml);
-                $url .= '&itemcdid=' . $cdid;
+                $mform->addElement(
+                    'static',
+                    'currentsubmission',
+                    get_string('currentsubmission', 'assignsubmission_estream'),
+                    $iframehtml
+                );
+                $url->param('itemcdid', $cdid);
             }
         }
-       $html = '<script type="text/javascript">';
+        $html = '<script type="text/javascript">';
         $html .= 'document.getElementById("hdn_cdid").value="' . $cdid . '";';
         $html .= 'document.getElementById("hdn_embedcode").value="' . $embedcode . '";';
         $html .= '</script>';
-   
+
         $html .= '<div style="padding-left: 15px; padding-top: 8px; width: 900px; height: 800px; line-height: 160%;">';
-	    $html .= get_config('assignsubmission_estream', 'helptext') . '<br />';
-		 $html .= get_string('upload_help', 'assignsubmission_estream') . '<br />';
-        $html .= '<iframe allow="camera;microphone;display-capture;" src="'.$url.'" width="90%" height="775px" noresize frameborder="0"></iframe>';
+        $html .= get_config('assignsubmission_estream', 'helptext') . '<br />';
+        $html .= get_string('upload_help', 'assignsubmission_estream') . '<br />';
+        $html .= '<iframe allow="camera;microphone;display-capture;" src="' . $url->out(false) . '" width="90%" height="775px" noresize frameborder="0"></iframe>';
         $html .= '</div>';
         $mform->addElement('hidden', 'cdid', '', array('id' => 'hdn_cdid'));
         $mform->addElement('hidden', 'embedcode', '', array('id' => 'hdn_embedcode'));

--- a/locallib.php
+++ b/locallib.php
@@ -24,6 +24,19 @@
  *
  */
 defined('MOODLE_INTERNAL') || die();
+
+if (!function_exists('assignsubmission_estream_get_cachebuster')) {
+    /**
+     * Build a per-request cache-busting token for iframe URLs.
+     *
+     * @return string
+     */
+    function assignsubmission_estream_get_cachebuster()
+    {
+        return preg_replace('/[^0-9]/', '', sprintf('%.6f', microtime(true)));
+    }
+}
+
 class assign_submission_estream extends assign_submission_plugin
 {
     /**
@@ -76,6 +89,7 @@ class assign_submission_estream extends assign_submission_plugin
     public function funcembedplayer($cdid, $embedcode)
     {
         $url = rtrim(get_config('assignsubmission_estream', 'url'), '/');
+        $cachebuster = assignsubmission_estream_get_cachebuster();
         if ($cdid == "") {
             return "<p>" . get_config('assignsubmission_estream', 'emptyoverride') . "</p>";
         } else {
@@ -89,7 +103,8 @@ class assign_submission_estream extends assign_submission_plugin
                 for ($i = 0; $i < count($CDIDs); $i++) {
 
                     $strReturn .= "<iframe allowfullscreen height=\"198\" width=\"352\" src=\"" . $url . "/Embed.aspx?id=" . $CDIDs[$i]
-                        . "&amp;code=" . $Codes[$i] . "&amp;wmode=opaque&amp;viewonestream=0\" frameborder=\"0\"></iframe>&nbsp;";
+                        . "&amp;code=" . $Codes[$i] . "&amp;wmode=opaque&amp;viewonestream=0&amp;cb=" . $cachebuster
+                        . "\" frameborder=\"0\"></iframe>&nbsp;";
                 }
 
                 return $strReturn;
@@ -98,7 +113,8 @@ class assign_submission_estream extends assign_submission_plugin
             } else {
 
                 return "<iframe allowfullscreen height=\"198\" width=\"352\" src=\"" . $url . "/Embed.aspx?id=" . $cdid
-                    . "&amp;code=" . $embedcode . "&amp;wmode=opaque&amp;viewonestream=0\" frameborder=\"0\"></iframe>";
+                    . "&amp;code=" . $embedcode . "&amp;wmode=opaque&amp;viewonestream=0&amp;cb=" . $cachebuster
+                    . "\" frameborder=\"0\"></iframe>";
             }
         }
     }
@@ -353,7 +369,8 @@ class assign_submission_estream extends assign_submission_plugin
         $embedcode = "";
         $url = new moodle_url('/mod/assign/submission/estream/upload.php', array(
             'id' => $this->assignment->get_course_module()->id,
-            'sesskey' => sesskey()
+            'sesskey' => sesskey(),
+            'cb' => assignsubmission_estream_get_cachebuster()
         ));
         $itemtitle = "Submission by " . fullname($USER);
         if (strlen($itemtitle) > 120) {

--- a/settings.php
+++ b/settings.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * Settings for the Planet eStream Assignment Submission Plugin
  *
@@ -21,32 +22,53 @@
  * @license        http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  */
-$settings->add(new admin_setting_configcheckbox('assignsubmission_estream/default',
-new lang_string('default', 'assignsubmission_estream'),
-new lang_string('default_help', 'assignsubmission_estream') , 1));
+$settings->add(new admin_setting_configcheckbox(
+    'assignsubmission_estream/default',
+    new lang_string('default', 'assignsubmission_estream'),
+    new lang_string('default_help', 'assignsubmission_estream'),
+    1
+));
 
-$settings->add(new admin_setting_configtext('assignsubmission_estream/url',
-new lang_string('settingsurl', 'assignsubmission_estream'),
-new lang_string('settingsurl_help', 'assignsubmission_estream'), PARAM_URL));;
+$settings->add(new admin_setting_configtext(
+    'assignsubmission_estream/url',
+    new lang_string('settingsurl', 'assignsubmission_estream'),
+    new lang_string('settingsurl_help', 'assignsubmission_estream'),
+    PARAM_URL
+));;
 
-$settings->add(new admin_setting_configcheckbox('assignsubmission_estream/usemail',
-new lang_string('settingsusemail', 'assignsubmission_estream'),
-new lang_string('settingsusemail_help', 'assignsubmission_estream'), PARAM_BOOL));;
+$settings->add(new admin_setting_configcheckbox(
+    'assignsubmission_estream/usemail',
+    new lang_string('settingsusemail', 'assignsubmission_estream'),
+    new lang_string('settingsusemail_help', 'assignsubmission_estream'),
+    PARAM_BOOL
+));;
 
-$settings->add(new admin_setting_configtext('assignsubmission_estream/emptyoverride',
-new lang_string('emptyoverride', 'assignsubmission_estream'),
-new lang_string('emptyoverride_help', 'assignsubmission_estream'),
-'Nothing was submitted via the Planet eStream plugin. Please ensure you upload the file in the plugin window before clicking Save Changes.' , PARAM_TEXT));
+$settings->add(new admin_setting_configtext(
+    'assignsubmission_estream/emptyoverride',
+    new lang_string('emptyoverride', 'assignsubmission_estream'),
+    new lang_string('emptyoverride_help', 'assignsubmission_estream'),
+    'Nothing was submitted via the Planet eStream plugin. Please ensure you upload the file in the plugin window before clicking Save Changes.',
+    PARAM_TEXT
+));
 
-$settings->add(new admin_setting_configtext('assignsubmission_estream/helptext',
-new lang_string('helptext', 'assignsubmission_estream'),
-new lang_string('helptext_help', 'assignsubmission_estream'),
-'' , PARAM_TEXT));
+$settings->add(new admin_setting_configtext(
+    'assignsubmission_estream/helptext',
+    new lang_string('helptext', 'assignsubmission_estream'),
+    new lang_string('helptext_help', 'assignsubmission_estream'),
+    '',
+    PARAM_TEXT
+));
 
-$settings->add(new admin_setting_configcheckbox('assignsubmission_estream/forcesubmit',
-new lang_string('forcesubmit', 'assignsubmission_estream'),
-new lang_string('forcesubmit_help', 'assignsubmission_estream'), PARAM_BOOL));;
+$settings->add(new admin_setting_configcheckbox(
+    'assignsubmission_estream/forcesubmit',
+    new lang_string('forcesubmit', 'assignsubmission_estream'),
+    new lang_string('forcesubmit_help', 'assignsubmission_estream'),
+    PARAM_BOOL
+));;
 
-$settings->add(new admin_setting_configcheckbox('assignsubmission_estream/overwriteblank',
-new lang_string('overwriteblank', 'assignsubmission_estream'),
-new lang_string('overwriteblank_help', 'assignsubmission_estream'), PARAM_BOOL));;
+$settings->add(new admin_setting_configcheckbox(
+    'assignsubmission_estream/overwriteblank',
+    new lang_string('overwriteblank', 'assignsubmission_estream'),
+    new lang_string('overwriteblank_help', 'assignsubmission_estream'),
+    PARAM_BOOL
+));;

--- a/upload.php
+++ b/upload.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * Planet eStream Assignment Submission Plugin Upload code
  *
@@ -24,57 +25,117 @@
 require_once('../../../../config.php');
 require_once($CFG->dirroot . '/mod/assign/locallib.php');
 require_once($CFG->dirroot . '/mod/assign/submission/estream/locallib.php');
+
+function assignsubmission_estream_render_message($message)
+{
+?>
+    <html>
+
+    <head>
+        <style type="text/css">
+            * {
+                font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+            }
+        </style>
+    </head>
+
+    <body>
+        <h3><?php echo $message; ?></h3>
+    </body>
+
+    </html>
+<?php
+}
+
 global $PAGE, $USER;
-require_login();
-$PAGE->set_context(context_user::instance($USER->id));
-profile_load_data($USER);
-$params = array();
-    //$params['usercontextid'] = $usercontextid;
-if (isset($USER->profile_field_planetestreamusername) && !empty($USER->profile_field_planetestreamusername)) {
-    $delta = atto_planetestream_obfuscate($USER->profile_field_planetestreamusername);
-	} else {
-		//here
-	if (get_config('assignsubmission_estream', 'usemail') == true) {
-		$delta = atto_planetestream_obfuscate($USER->email);
-	} else {
-		$delta = atto_planetestream_obfuscate($USER->username);
-	}	
-	}
-	$userip = atto_planetestream_obfuscate(getremoteaddr());
-	$baseurl = rtrim(get_config('assignsubmission_estream', 'url') , '/');
-	$params['estream_url'] = $baseurl;
-	$checksum = atto_planetestream_getchecksum();
-	$authticket = atto_planetestream_getauthticket($baseurl, $checksum, $delta, $userip, $params);
-	if ($authticket == '') {
-       $params['disabled'] = true; //may not need
-    }
-	
-$PAGE->set_url($CFG->wwwroot . '/mod/assign/submission/estream/upload.php');
 $itemtitle = optional_param('itemtitle', '', PARAM_TEXT);
 $itemdesc = optional_param('itemdesc', '', PARAM_TEXT);
-$itemcid = optional_param('itemcid', '', PARAM_TEXT);
+$itemcid = optional_param('itemcid', 0, PARAM_INT);
 $itemcdid = optional_param('itemcdid', '', PARAM_TEXT);
-$itemaid = optional_param('itemaid', '', PARAM_TEXT);
-$itemuid = optional_param('itemuid', '', PARAM_TEXT);
+$itemaid = optional_param('itemaid', 0, PARAM_INT);
+$itemuid = optional_param('itemuid', $USER->id, PARAM_INT);
 $cdid = optional_param('cdid', '', PARAM_TEXT);
 $embedcode = optional_param('ec', '', PARAM_TEXT);
 $error = optional_param('error', '', PARAM_TEXT);
 $configerror = optional_param('configerror', '', PARAM_TEXT);
-function atto_planetestream_getchecksum() {
+
+if (empty($itemtitle)) {
+    require_login();
+    $PAGE->set_context(context_user::instance($USER->id));
+    $PAGE->set_url(new moodle_url('/mod/assign/submission/estream/upload.php'));
+    $cm = null;
+    $course = null;
+    $context = $PAGE->context;
+    $assignment = null;
+} else {
+    $id = required_param('id', PARAM_INT);
+    $cm = get_coursemodule_from_id('assign', $id, 0, false, MUST_EXIST);
+    $course = get_course($cm->course);
+    $context = context_module::instance($cm->id);
+    require_login($course, true, $cm);
+    require_sesskey();
+    $PAGE->set_context($context);
+    $PAGE->set_url(new moodle_url('/mod/assign/submission/estream/upload.php', array('id' => $cm->id)));
+    $assignment = new assign($context, $cm, $course);
+
+    if (!empty($itemaid) && (int)$itemaid !== (int)$assignment->get_instance()->id) {
+        assignsubmission_estream_render_message(get_string('invalidcoursemodule', 'error'));
+        die();
+    }
+
+    if (!empty($itemcid) && (int)$itemcid !== (int)$course->id) {
+        assignsubmission_estream_render_message(get_string('invalidcourseid', 'error'));
+        die();
+    }
+
+    if ((int)$itemuid !== (int)$USER->id && !$assignment->can_edit_submission($itemuid)) {
+        throw new required_capability_exception($context, 'mod/assign:editothersubmission', 'nopermissions', '');
+    }
+
+    if ((int)$itemuid === (int)$USER->id && !$assignment->can_edit_submission($USER->id)) {
+        throw new required_capability_exception($context, 'mod/assign:submit', 'nopermissions', '');
+    }
+}
+
+profile_load_data($USER);
+$params = array();
+
+if (isset($USER->profile_field_planetestreamusername) && !empty($USER->profile_field_planetestreamusername)) {
+    $delta = atto_planetestream_obfuscate($USER->profile_field_planetestreamusername);
+} else {
+    //here
+    if (get_config('assignsubmission_estream', 'usemail') == true) {
+        $delta = atto_planetestream_obfuscate($USER->email);
+    } else {
+        $delta = atto_planetestream_obfuscate($USER->username);
+    }
+}
+$userip = atto_planetestream_obfuscate(getremoteaddr());
+$baseurl = rtrim(get_config('assignsubmission_estream', 'url'), '/');
+$params['estream_url'] = $baseurl;
+$checksum = atto_planetestream_getchecksum();
+$authticket = atto_planetestream_getauthticket($baseurl, $checksum, $delta, $userip, $params);
+if ($authticket == '') {
+    $params['disabled'] = true; //may not need
+}
+
+function atto_planetestream_getchecksum()
+{
     $decchecksum = (float)(date('d') + date('m')) + (date('m') * date('d')) + (date('Y') * date('d'));
     $decchecksum += $decchecksum * (date('d') * 2.27409) * .689274;
     return md5(floor($decchecksum));
 }
 
-function atto_planetestream_getauthticket($url, $checksum, $delta, $userip, &$params) {
+function atto_planetestream_getauthticket($url, $checksum, $delta, $userip, &$params)
+{
     $return = '';
-	
-	//$return = $url . "~~~" . $checksum . "~~~~" . $delta . "~~~~" . $userip;
+
+    //$return = $url . "~~~" . $checksum . "~~~~" . $delta . "~~~~" . $userip;
     try {
         $url .= '/VLE/Moodle/Auth/?source=1&assign=1&checksum=' . $checksum . '&delta=' . $delta . '&u=' . $userip;
         if (!$curl = curl_init($url)) {
-           return '';
-		   //return $return;
+            return '';
+            //return $return;
         }
         curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 15);
         curl_setopt($curl, CURLOPT_TIMEOUT, 15);
@@ -96,19 +157,20 @@ function atto_planetestream_getauthticket($url, $checksum, $delta, $userip, &$pa
     return $return;
 }
 
-function atto_planetestream_obfuscate($strx) {
+function atto_planetestream_obfuscate($strx)
+{
     $strbase64chars = '0123456789aAbBcCDdEeFfgGHhiIJjKklLmMNnoOpPQqRrsSTtuUvVwWXxyYZz/+=';
     $strbase64string = base64_encode($strx);
     if ($strbase64string == '') {
         return '';
     }
     $strobfuscated = '';
-    for ($i = 0; $i < strlen ($strbase64string); $i ++) {
+    for ($i = 0; $i < strlen($strbase64string); $i++) {
         $intpos = strpos($strbase64chars, substr($strbase64string, $i, 1));
-        if ($intpos == - 1) {
+        if ($intpos == -1) {
             return '';
         }
-        $intpos += strlen($strbase64string ) + $i;
+        $intpos += strlen($strbase64string) + $i;
         $intpos = $intpos % strlen($strbase64chars);
         $strobfuscated .= substr($strbase64chars, $intpos, 1);
     }
@@ -117,88 +179,47 @@ function atto_planetestream_obfuscate($strx) {
 if (empty($itemtitle)) {
     if (empty($error) && empty($configerror) && !empty($cdid)) {
 ?>
-<html>
-    <head>
-        <script type="text/javascript">
-            function page_load() {
-                parent.parent.document.getElementById('hdn_cdid').value = "<?php echo $cdid; ?>";
-                parent.parent.document.getElementById('hdn_embedcode').value = "<?php echo $embedcode; ?>";
-            }
-        </script>
-        <style type="text/css">
-            * {
-                font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-            }
-        </style>
-    </head>
-    <body onload="page_load()" >
-            <h3><?php echo get_string('uploadok', 'assignsubmission_estream'); ?></h3>
-    </body>
-</html>
-<?php
-    } else {
-?>
-    <html>
+        <html>
+
         <head>
+            <script type="text/javascript">
+                function page_load() {
+                    parent.parent.document.getElementById('hdn_cdid').value = "<?php echo $cdid; ?>";
+                    parent.parent.document.getElementById('hdn_embedcode').value = "<?php echo $embedcode; ?>";
+                }
+            </script>
             <style type="text/css">
                 * {
                     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
                 }
-
             </style>
         </head>
-        <body>
-            <h3><?php
-        if (empty($configerror)) {
-            echo get_string('uploadfailed', 'assignsubmission_estream') . '<br />' . $error;
-        } else {
-            echo $configerror;
-        } ?>    </h3>
+
+        <body onload="page_load()">
+            <h3><?php echo get_string('uploadok', 'assignsubmission_estream'); ?></h3>
         </body>
-    </html>
-<?php
+
+        </html>
+    <?php
+    } else {
+        $message = empty($configerror) ? get_string('uploadfailed', 'assignsubmission_estream') . '<br />' . s($error) : s($configerror);
+        assignsubmission_estream_render_message($message);
     }
 } else {
-    $thissubmission = new assign_submission_estream(new assign(null, null, null) , null);
-    if (empty($thissubmission)) {
-        echo "Sorry, the submission could not be initiated.";
-        die();
-    }
-    //$baseurl = rtrim(get_config('assignsubmission_estream', 'url') , '/');
-  
     if (empty($baseurl)) {
-?>
-    <html>
-        <head>
-            <style type="text/css">
-                * {
-                    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-                }
-            </style>
-        </head>
-        <body>
-            <h3><?php echo get_string('notyetconfigured', 'assignsubmission_estream') ?></h3>
-        </body>
-     </html>
-<?php
+        assignsubmission_estream_render_message(get_string('notyetconfigured', 'assignsubmission_estream'));
     } else {
-?>
+        $callbackurl = $CFG->wwwroot . '/mod/assign/submission/estream/upload.php';
+    ?>
         <script type="text/javascript">
-
-                // parent.parent.document.getElementById("id_submitbutton").disabled = true;
-
+            // parent.parent.document.getElementById("id_submitbutton").disabled = true;
         </script>
-       <!-- <div style="text-align: center;">
+        <!-- <div style="text-align: center;">
                 <iframe width="90%" height="700px"  allow="camera;microphone;display-capture;" frameborder="0" src="https://labs.planetestream.com/Embed.aspx?id=519&amp;code=fQ~xKpfoMIyMGtlr7uQUaWR9L7wLslZ&min=1"></iframe>
         </div>-->
-		<div style="text-align: center;">
-                <iframe width="90%" height="700px" allow="camera;microphone;display-capture;" frameborder="0" src="<?php echo $baseurl; ?>/VLE/Moodle/Default.aspx?sourceid=11&inlinemode=moodle&delta=<?php echo $delta?>&checksum=<?php echo $checksum; ?>&itemcdid=<?php echo $itemcdid; ?>&assign=<?php echo ((string)$PAGE->pagetype == 'mod-assign-editsubmission' ? "true" : "false"); ?>&assignmoodle=<?php echo ((string)$PAGE->pagetype == 'mod-assign-submission-estream-upload' ? "true" : "false"); ?>&ticket=<?php echo urlencode($authticket); ?>&murl=
-				<?php 
-                echo $CFG->wwwroot.'/mod/assign/submission/estream/upload.php'
-                .'&amp;title='.urlencode($itemtitle).'&amp;desc='.urlencode($itemdesc)
-                .'&amp;cid='.urlencode($itemcid).'&amp;aid='.urlencode($itemaid)				
-                .'&amp;uid='.urlencode($itemuid).'&amp;cdid='				
-                .$itemcdid;?>"></iframe>
+        <div style="text-align: center;">
+            <iframe width="90%" height="700px" allow="camera;microphone;display-capture;" frameborder="0" src="<?php
+                echo s($baseurl); ?>/VLE/Moodle/Default.aspx?sourceid=11&inlinemode=moodle&delta=<?php echo s($delta) ?>&checksum=<?php echo s($checksum); ?>&itemcdid=<?php echo s($itemcdid); ?>&assign=false&assignmoodle=true&aid=<?php echo urlencode((string)$itemaid); ?>&cid=<?php echo urlencode((string)$itemcid); ?>&uid=<?php echo urlencode((string)$itemuid); ?>&title=<?php echo urlencode($itemtitle); ?>&desc=<?php echo urlencode($itemdesc); ?>&ticket=<?php echo urlencode($authticket); ?>&murl=<?php echo s($callbackurl); ?>"></iframe>
         </div>
 <?php
     }

--- a/upload.php
+++ b/upload.php
@@ -26,6 +26,10 @@ require_once('../../../../config.php');
 require_once($CFG->dirroot . '/mod/assign/locallib.php');
 require_once($CFG->dirroot . '/mod/assign/submission/estream/locallib.php');
 
+header('Cache-Control: private, no-store, no-cache, must-revalidate, max-age=0');
+header('Pragma: no-cache');
+header('Expires: 0');
+
 function assignsubmission_estream_render_message($message)
 {
 ?>
@@ -210,6 +214,7 @@ if (empty($itemtitle)) {
         assignsubmission_estream_render_message(get_string('notyetconfigured', 'assignsubmission_estream'));
     } else {
         $callbackurl = $CFG->wwwroot . '/mod/assign/submission/estream/upload.php';
+        $cachebuster = assignsubmission_estream_get_cachebuster();
     ?>
         <script type="text/javascript">
             // parent.parent.document.getElementById("id_submitbutton").disabled = true;
@@ -219,7 +224,7 @@ if (empty($itemtitle)) {
         </div>-->
         <div style="text-align: center;">
             <iframe width="90%" height="700px" allow="camera;microphone;display-capture;" frameborder="0" src="<?php
-                echo s($baseurl); ?>/VLE/Moodle/Default.aspx?sourceid=11&inlinemode=moodle&delta=<?php echo s($delta) ?>&checksum=<?php echo s($checksum); ?>&itemcdid=<?php echo s($itemcdid); ?>&assign=false&assignmoodle=true&aid=<?php echo urlencode((string)$itemaid); ?>&cid=<?php echo urlencode((string)$itemcid); ?>&uid=<?php echo urlencode((string)$itemuid); ?>&title=<?php echo urlencode($itemtitle); ?>&desc=<?php echo urlencode($itemdesc); ?>&ticket=<?php echo urlencode($authticket); ?>&murl=<?php echo s($callbackurl); ?>"></iframe>
+                echo s($baseurl); ?>/VLE/Moodle/Default.aspx?sourceid=11&inlinemode=moodle&delta=<?php echo s($delta) ?>&checksum=<?php echo s($checksum); ?>&itemcdid=<?php echo s($itemcdid); ?>&assign=false&assignmoodle=true&aid=<?php echo urlencode((string)$itemaid); ?>&cid=<?php echo urlencode((string)$itemcid); ?>&uid=<?php echo urlencode((string)$itemuid); ?>&title=<?php echo urlencode($itemtitle); ?>&desc=<?php echo urlencode($itemdesc); ?>&ticket=<?php echo urlencode($authticket); ?>&murl=<?php echo s($callbackurl); ?>&cb=<?php echo s($cachebuster); ?>"></iframe>
         </div>
 <?php
     }

--- a/version.php
+++ b/version.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * version information for the Planet eStream Assignment Submission Plugin
  * extends submission plugin base class
@@ -23,8 +24,8 @@
  *
  */
 defined('MOODLE_INTERNAL') || die();
-$plugin->version = 2024072500;
-$plugin->requires = 2012062500;
+$plugin->version = 2026032600;
+$plugin->requires = 2025092600;
 $plugin->component = 'assignsubmission_estream';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '6.7.23';
+$plugin->release = '6.7.24';


### PR DESCRIPTION
This PR is mostly a general cleanup of the Planet eStream submission plugin, along with a few changes to improve how submissions work in practice. It tidies up the code, fixes the privacy provider, and improves the way submissions are saved, checked, and displayed.

It also fixes an issue where students could upload to any assignment point in VLE submissions if they knew the IDs and embedded the page themselves, by tightening the upload and permission checks. Alongside that, it adds a few improvements to make the submission experience smoother and more reliable for users regarding removing submissions.


